### PR TITLE
Make `patch.sh` locate the Bash binary in a flexible way.

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 FILENAME="./chunk~547eb3232.css"
 # set display to none


### PR DESCRIPTION
By using `#!/usr/bin/env bash`, the `env` executable locates the Bash installation even if it's located in a non-standard location.

For more info: https://stackoverflow.com/a/16365367